### PR TITLE
Marcos customs

### DIFF
--- a/bemo/blocks/_align.sass
+++ b/bemo/blocks/_align.sass
@@ -1,0 +1,8 @@
+@each $direction in $align-directions
+  .align--#{$direction}
+    text-align: #{$direction}
+
+  @each $name in $align-breakpoints
+    .align-#{$direction}--on-#{$name}
+      +at-breakpoint($name)
+        text-align: #{$direction}

--- a/bemo/blocks/_space.sass
+++ b/bemo/blocks/_space.sass
@@ -1,9 +1,13 @@
 @each $amount in $space-amounts
-  @each $rule in bottom top
-    .space--#{$rule}-#{$amount}
-      +space-rule("margin-#{$rule}", $amount)
+  @each $direction in $space-directions
+    .space--#{$direction}-#{$amount}
+      +space-rule("margin-#{$direction}", $amount)
+
+    @each $name in $space-breakpoints
+      .space-#{$direction}-#{$amount}--on-#{$name}
+        +at-breakpoint($name)
+          +space-rule("margin-#{$direction}", $amount)
 
   .space--both-#{$amount}
-    +margin-top($amount)
-    +margin-bottom($amount)
-
+    +space-rule("margin-top", $amount)
+    +space-rule("margin-bottom", $amount)

--- a/bemo/formats/_align.sass
+++ b/bemo/formats/_align.sass
@@ -1,6 +1,0 @@
-.align--right
-  text-align: right
-
-.align--center
-  text-align: center
-

--- a/bemo/variables/_align.sass
+++ b/bemo/variables/_align.sass
@@ -1,0 +1,2 @@
+$align-directions: ( left center right )
+$align-breakpoints: ( desk )

--- a/bemo/variables/_breakpoints.sass
+++ b/bemo/variables/_breakpoints.sass
@@ -1,23 +1,25 @@
-// 0px            480px           1024x           1500px           ∞
-// |               |               |                |              |
-// |               |<-- lap -------------------------------------->|
-// |               |               |<-- desk --------------------->|
-// |               |               |                |<-- wall ---->|
-// |               |               |                |              |
-// |<-- eq-palm -->|               |                |              |
-// |               |<-- eq-lap --->|                |              |
-// |               |               |<-- eq-desk --->|              |
-// |               |               |                |              |
-// |<------------------ lte-lap -->|                |              |
-// |<---------------------------------- lte-desk -->|              |
-// |               |               |                |              |
-// 0px            480x           1024px          1500px            ∞
+// 0px            480px          720px           1024px         1500px             ∞
+// |               |               |                |               |              |
+// |               |<-- tab ------------------------------------------------------>|
+// |               |               |<-- lap -------------------------------------->|
+// |               |               |                |<-- desk -------------------->|
+// |               |               |                |               |<-- wall ---->|
+// |               |               |                |               |              |
+// |<-- eq-palm -->|               |                |               |              |
+// |               |<-- eq-tab --->|                |               |              |
+// |               |               |<-- eq-lap ---->|               |              |
+// |               |               |                |               |              |
+// |               |               |                |<-- eq-desk -->|              |
+// |<------------------ lte-tab -->|                |               |              |
+// |<----------------------------------- lte-lap -->|               |              |
+// |<-------------------------------------------------- lte-desk -->|              |
+// |               |               |                |               |              |
+// 0px            480px          720px           1024px          1500px            ∞
 
 // define breakpoints
-$breakpoint-widths: ('palm': 0px, 'lap': 480px, 'desk': 1024px, 'wall': 1500px)
+$breakpoint-widths: ('palm': 0px, 'tab': 480px, 'lap': 720px, 'desk': 1024px, 'wall': 1500px)
 
 // derived variables
 $breakpoint-names: breakpoint-names($breakpoint-widths)
 $breakpoint-media-queries: breakpoint-media-queries($breakpoint-widths)
 $breakpoint-inverse-media-queries: breakpoint-inverse-media-queries($breakpoint-widths)
-

--- a/bemo/variables/_font-size.sass
+++ b/bemo/variables/_font-size.sass
@@ -1,8 +1,7 @@
 $base-font-size: 15px
-$heading-font-sizes: ('alpha': 30px, 'beta': 27px, 'gamma': 22px)
+$heading-font-sizes: ('alpha': 30px, 'beta': 27px, 'gamma': 22px, 'delta': 18px)
 $smallprint-font-sizes: ('smallprint': 13px, 'milli': 12px)
 
 // derived
 $all-font-sizes: map-merge($heading-font-sizes, $smallprint-font-sizes)
 $all-font-sizes: map-merge($all-font-sizes, ('regular': $base-font-size))
-

--- a/bemo/variables/_space.sass
+++ b/bemo/variables/_space.sass
@@ -1,3 +1,4 @@
 $space-unit: 12px
 $space-amounts: ( 1, 2, 3, 5, 8 )
-
+$space-directions: ( top bottom )
+$space-breakpoints: ( desk )


### PR DESCRIPTION
hi @stefanoverna here an explanation:

responsive align common case: two grid items desk-6-12, the first one contains text, another one contains an image. in the smartphone view both are center aligned. in the desktop view the text has to be left aligned, the image right aligned.

responsive space common case: cause the font size is responsive, also the vertical space could be, to provide a more compact ui in the smartphone view, and a more spaced ui in the desktop view

a 18px heading title is quite commod, also a 720px breakpoint, named "lap" cause the laptop screen is likely wider then a tablet one.