### PR TITLE
Flexbox based grid.

### DIFF
--- a/bemo/blocks/_grid.sass
+++ b/bemo/blocks/_grid.sass
@@ -43,22 +43,30 @@
 .grid--right
   @extend .grid
   text-align: right
+  justify-content: flex-end
   > .grid__item
     text-align: left
 
 .grid--center
   @extend .grid
   text-align: center
+  justify-content: center
   > .grid__item
     text-align: left
 
 .grid--middle
   @extend .grid
+  align-items: center
   > .grid__item
     vertical-align: middle
 
+.grid--center--middle, .grid--middle--center
+  @extend .grid--center
+  @extend .grid--middle
+
 .grid--bottom
   @extend .grid
+  align-items: flex-end
   > .grid__item
     vertical-align: bottom
 

--- a/bemo/mixins/_grid.sass
+++ b/bemo/mixins/_grid.sass
@@ -1,17 +1,22 @@
-@mixin grid
+@mixin grid($flex-grid: true)
   list-style: none
   margin-right: 0
   margin-left: -$grid-gutter
   padding-left: 0
   padding-right: 0
   letter-spacing: -1000em
+  @if $flex-grid
+    display: flex
+    align-content: flex-start
+    flex-direction: row
+    flex-wrap: wrap
 
-@mixin grid-item
+@mixin grid-item($flex-grid: true)
   display: inline-block
   padding-left: $grid-gutter
   vertical-align: top
   width: 100%
+  letter-spacing: 0
   -webkit-box-sizing: border-box
   -moz-box-sizing: border-box
   box-sizing: border-box
-  letter-spacing: 0


### PR DESCRIPTION
I added a boolean variable ($flex-grid) to the grid mixin to control if the flexbox based grid is active or not. It is activated by default since it degrades nicely in older browsers but, in case, you can disable it completely.

I also added a new modifier for vertical and horizontal centered grid: .grid--center--middle (with a synonymous class: .grid--middle--center).